### PR TITLE
Fix wrong event provider namespace in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        \SocialiteProviders\QQ\QQExtendSocialite::class.'@handle',
+        \SocialiteProviders\QQ\QqExtendSocialite::class.'@handle',
     ],
 ];
 ```


### PR DESCRIPTION
This PR fixes the issue in https://github.com/SocialiteProviders/Providers/issues/775, where the namespace in the event provider does not match the actual class name. Notice the double uppercase Q's in the example as opposed to the single uppercase in the class name.

https://github.com/SocialiteProviders/QQ/blob/00bf77170e73be69eb6fe661def3aa1ae5b7035d/QqExtendSocialite.php#L7